### PR TITLE
Fix a typo in the package description (was: relax version bounds).

### DIFF
--- a/orthotope.cabal
+++ b/orthotope.cabal
@@ -7,7 +7,7 @@ copyright:           2018 Google Inc
 category:            array
 maintainer:          lennart@augustsson.net
 description:         Multidimensional arrays inspired by APL.
-                     The library contains a wide variety of structurual
+                     The library contains a wide variety of structural
                      operations on arrays, but not actual algorithms.
 build-type:          Simple
 cabal-version:       >=1.10


### PR DESCRIPTION
I determined this bound by using `stack` to build with successively
earlier resolvers until it failed.  This is a particularly convenient
outcome, because it should fix what went wrong when generating Hackage
docs (namely that it built with GHC 8.6.3, failed to find a plan, and
gave up forever) in one of two ways: either it triggers a new build,
uses a newer version, and works; or it triggers a build still using 8.6,
and it's now supported and works.

The limiting factor: QuantifiedConstraints introduced in GHC 8.6