### PR TITLE
Correct Haddock for reshape: it can't fail for shaped Arrays

### DIFF
--- a/Data/Array/Internal/ShapedS.hs
+++ b/Data/Array/Internal/ShapedS.hs
@@ -136,7 +136,7 @@ fromVector = A . G.fromVector
 normalize :: (Unbox a, Shape sh) => Array sh a -> Array sh a
 normalize = A . G.normalize . unA
 
--- | Change the shape of an array.  Fails if the arrays have different number of elements.
+-- | Change the shape of an array.  Type error if the arrays have different number of elements.
 -- O(n) or O(1) time.
 reshape :: forall sh' sh a . (Unbox a, Shape sh, Shape sh', Size sh ~ Size sh') =>
            Array sh a -> Array sh' a

--- a/Data/Array/Internal/ShapedU.hs
+++ b/Data/Array/Internal/ShapedU.hs
@@ -134,7 +134,7 @@ fromVector = A . G.fromVector
 normalize :: (Unbox a, Shape sh) => Array sh a -> Array sh a
 normalize = A . G.normalize . unA
 
--- | Change the shape of an array.  Fails if the arrays have different number of elements.
+-- | Change the shape of an array.  Type error if the arrays have different number of elements.
 -- O(n) or O(1) time.
 reshape :: forall sh' sh a . (Unbox a, Shape sh, Shape sh', Size sh ~ Size sh') =>
            Array sh a -> Array sh' a


### PR DESCRIPTION
This brings the documentation for ShapedS and ShapedU in line with
ShapedG, which already says this.

(I think this is correct isn't it? It's (part of) the point of having shaped arrays!)