### PR TITLE
Mark INLINABLE more functions

### DIFF
--- a/Data/Array/Internal.hs
+++ b/Data/Array/Internal.hs
@@ -144,6 +144,7 @@ badShape = any (< 0)
 
 -- When shapes match, we can be efficient and use loop-fused comparisons instead
 -- of materializing a list.
+{-# INLINABLE equalT #-}
 equalT :: (Vector v, VecElem v a, Eq a, Eq (v a))
                   => ShapeL -> T v a -> T v a -> Bool
 equalT s x y | strides x == strides y
@@ -152,6 +153,7 @@ equalT s x y | strides x == strides y
              | otherwise = toVectorT s x == toVectorT s y
 
 -- Note this assumes the shape is the same for both Vectors.
+{-# INLINABLE compareT #-}
 compareT :: (Vector v, VecElem v a, Ord a, Ord (v a))
             => ShapeL -> T v a -> T v a -> Ordering
 compareT s x y = compare (toVectorT s x) (toVectorT s y)

--- a/Data/Array/Internal/Ranked.hs
+++ b/Data/Array/Internal/Ranked.hs
@@ -111,6 +111,7 @@ toList = G.toList . unA
 -- | Convert from a list with the elements given in the linearization order.
 -- Fails if the given shape does not have the same number of elements as the list.
 -- O(n) time.
+{-# INLINABLE fromList #-}
 fromList :: forall n a . (KnownNat n) => ShapeL -> [a] -> Array n a
 fromList ss = A . G.fromList ss
 
@@ -122,6 +123,7 @@ toVector = G.toVector . unA
 -- | Convert from a vector with the elements given in the linearization order.
 -- Fails if the given shape does not have the same number of elements as the list.
 -- O(1) time.
+{-# INLINABLE fromVector #-}
 fromVector :: forall n a . (KnownNat n) => ShapeL -> V.Vector a -> Array n a
 fromVector ss = A . G.fromVector ss
 

--- a/Data/Array/Internal/RankedG.hs
+++ b/Data/Array/Internal/RankedG.hs
@@ -395,6 +395,7 @@ rerank f (A sh t) =
   subArraysT osh t
   where (osh, ish) = splitAt (valueOf @n) sh
 
+{-# INLINABLE ravelOuter #-}
 ravelOuter :: (Vector v, VecElem v a, KnownNat m) => ShapeL -> [Array n v a] -> Array m v a
 ravelOuter _ [] = error "ravelOuter: empty list"
 ravelOuter osh as | not $ allSame shs = error $ "ravelOuter: non-conforming inner dimensions: " ++ show shs

--- a/Data/Array/Internal/RankedS.hs
+++ b/Data/Array/Internal/RankedS.hs
@@ -141,6 +141,7 @@ normalize = A . G.normalize . unA
 
 -- | Change the shape of an array.  Fails if the arrays have different number of elements.
 -- O(n) or O(1) time.
+{-# INLINABLE reshape #-}
 reshape :: (Unbox a, KnownNat n, KnownNat n') => ShapeL -> Array n a -> Array n' a
 reshape s = A . G.reshape s . unA
 
@@ -171,6 +172,7 @@ constant sh = A . G.constant sh
 
 -- | Map over the array elements.
 -- O(n) time.
+{-# INLINABLE mapA #-}
 mapA :: (Unbox a, Unbox b) =>
         (a -> b) -> Array n a -> Array n b
 mapA f = A . G.mapA f . unA
@@ -196,12 +198,14 @@ pad ps v = A . G.pad ps v . unA
 -- Fails if the transposition argument is not a permutation of the numbers
 -- [0..r-1], where r is the rank of the array.
 -- O(1) time.
+{-# INLINABLE transpose #-}
 transpose :: (KnownNat n) => [Int] -> Array n a -> Array n a
 transpose is = A . G.transpose is . unA
 
 -- | Append two arrays along the outermost dimension.
 -- All dimensions, except the outermost, must be the same.
 -- O(n) time.
+{-# INLINABLE append #-}
 append :: (Unbox a, KnownNat n) => Array n a -> Array n a -> Array n a
 append x y = A $ G.append (unA x) (unA y)
 

--- a/Data/Array/Internal/ShapedS.hs
+++ b/Data/Array/Internal/ShapedS.hs
@@ -142,6 +142,7 @@ normalize = A . G.normalize . unA
 
 -- | Change the shape of an array.  Type error if the arrays have different number of elements.
 -- O(n) or O(1) time.
+{-# INLINABLE reshape #-}
 reshape :: forall sh' sh a . (Unbox a, Shape sh, Shape sh', Size sh ~ Size sh') =>
            Array sh a -> Array sh' a
 reshape = A . G.reshape . unA
@@ -174,6 +175,7 @@ constant = A . G.constant
 
 -- | Map over the array elements.
 -- O(n) time.
+{-# INLINABLE mapA #-}
 mapA :: (Unbox a, Unbox b, Shape sh) => (a -> b) -> Array sh a -> Array sh b
 mapA f = A . G.mapA f . unA
 
@@ -197,6 +199,7 @@ pad v = A . G.pad @ps v . unA
 -- Fails if the transposition argument is not a permutation of the numbers
 -- [0..r-1], where r is the rank of the array.
 -- O(1) time.
+{-# INLINABLE transpose #-}
 transpose :: forall is sh a .
              (Permutation is, Rank is <= Rank sh, Shape sh, Shape is, KnownNat (Rank sh)) =>
              Array sh a -> Array (Permute is sh) a
@@ -205,6 +208,7 @@ transpose = A . G.transpose @is . unA
 -- | Append two arrays along the outermost dimension.
 -- All dimensions, except the outermost, must be the same.
 -- O(n) time.
+{-# INLINABLE append #-}
 append :: (Unbox a, Shape sh, KnownNat m, KnownNat n, KnownNat (m+n)) =>
           Array (m ': sh) a -> Array (n ': sh) a -> Array (m+n ': sh) a
 append x y = A $ G.append (unA x) (unA y)


### PR DESCRIPTION
Mark INLINABLE more functions indicated by -Wall-missed-specialisations in horde-ad. After they are marked, the warnings no longer appear, so I hope this enables some blocked specializations (or prevents re-boxing and calling non-specialized functions in some elements of the call chain).