### PR TITLE
Modify Permutation to only allow actual permutations

### DIFF
--- a/Data/Array/Internal/Shape.hs
+++ b/Data/Array/Internal/Shape.hs
@@ -115,7 +115,7 @@ instance (KnownNat l, KnownNat h, (l+s+h) ~ s', Padded ps sh sh') =>
 -----------------
 
 class Permutation (is :: [Nat])
-instance (AllElem is (Count 0 is)) => Permutation is
+instance (AllElem is (Count 0 is), AllElem (Count 0 is) is) => Permutation is
 
 type family Count (i :: Nat) (xs :: [Nat]) :: [Nat] where
   Count i '[] = '[]


### PR DESCRIPTION
The original definition of the `Permutation` class allowed some lists that were not actually permutations, such as `[1, 1]`. This is because the constraints did require that all elements of the permutation array are valid indices into [1..n), but not that this mapping is bijective. Adding a reverse `AllElem` constraint corrects this.

Before this PR:
```
Prelude Data.Array.ShapedS> transpose @[1, 1] (fromList @[2, 3] @Double [1..6])
fromList @[3,3] [1.0,2.0,3.0,2.0,3.0,4.0,3.0,4.0,5.0]
Prelude Data.Array.ShapedS> transpose @[0, 0] (fromList @[2, 3] @Double [1..6])
fromList @[2,2] [1.0,4.0,4.0,*** Exception: index out of bounds (6,6)
```
After this PR, these invocations are rejected with a type error.