### PR TITLE
Don't require unused NFData constraints

### DIFF
--- a/Data/Array/Internal/DynamicS.hs
+++ b/Data/Array/Internal/DynamicS.hs
@@ -115,7 +115,7 @@ type role Array nominal
 newtype Array a = A { unA :: G.Array V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array a)
+instance NFData (Array a)
 
 instance (Show a, Unbox a) => Show (Array a) where
   showsPrec p = showsPrec p . unA

--- a/Data/Array/Internal/DynamicU.hs
+++ b/Data/Array/Internal/DynamicU.hs
@@ -112,7 +112,7 @@ type role Array nominal
 newtype Array a = A { unA :: G.Array V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array a)
+instance NFData (Array a)
 
 instance (Show a, Unbox a) => Show (Array a) where
   showsPrec p = showsPrec p . unA

--- a/Data/Array/Internal/RankedS.hs
+++ b/Data/Array/Internal/RankedS.hs
@@ -69,7 +69,7 @@ type role Array nominal nominal
 newtype Array n a = A { unA :: G.Array n V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array n a)
+instance NFData (Array n a)
 
 instance (Show a, Unbox a) => Show (Array n a) where
   showsPrec p = showsPrec p . unA

--- a/Data/Array/Internal/RankedU.hs
+++ b/Data/Array/Internal/RankedU.hs
@@ -68,7 +68,7 @@ type role Array nominal nominal
 newtype Array n a = A { unA :: G.Array n V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array n a)
+instance NFData (Array n a)
 
 instance (Show a, Unbox a) => Show (Array n a) where
   showsPrec p = showsPrec p . unA

--- a/Data/Array/Internal/ShapedS.hs
+++ b/Data/Array/Internal/ShapedS.hs
@@ -70,7 +70,7 @@ type role Array nominal nominal
 newtype Array sh a = A { unA :: G.Array sh V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array sh a)
+instance NFData (Array sh a)
 
 instance (Unbox a, Show a, Shape sh) => Show (Array sh a) where
   showsPrec p = showsPrec p . unA

--- a/Data/Array/Internal/ShapedU.hs
+++ b/Data/Array/Internal/ShapedU.hs
@@ -68,7 +68,7 @@ type role Array nominal nominal
 newtype Array sh a = A { unA :: G.Array sh V.Vector a }
   deriving (Pretty, Generic, Data)
 
-instance NFData a => NFData (Array sh a)
+instance NFData (Array sh a)
 
 instance (Unbox a, Show a, Shape sh) => Show (Array sh a) where
   showsPrec p = showsPrec p . unA


### PR DESCRIPTION
The Storable and Unboxed array data types are based on vectors that can be evaluated to normal form without an `NFData` constraint on their elements. Hence, the `NFData` instances on the storable and unboxed array types do not need an `NFData a` constraint: it's unused.

This PR removes the unused constraints.