### PR TITLE
Bump QuickCheck bound again for stackage, etc.

### DIFF
--- a/orthotope.cabal
+++ b/orthotope.cabal
@@ -18,7 +18,7 @@ extra-source-files:
       LICENSE
       README.md
 
-tested-with:         GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with:         GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.3 || ==9.12.2
 
 source-repository head
     type:     git
@@ -61,7 +61,7 @@ library
                      , Data.Array.Internal.ShapedU
 
   build-depends:       base             >= 4.12 && < 4.22,
-                       QuickCheck       >= 2.14.3 && < 2.17,
+                       QuickCheck       >= 2.14.3 && < 2.18,
                        deepseq          >= 1.4.4 && < 1.7,
                        pretty           >= 1.1.3 && < 1.2,
                        dlist            >= 1.0 && < 1.1,


### PR DESCRIPTION
This is due to https://github.com/commercialhaskell/stackage/issues/7857.

A new release is not needed if revision of bounds on Hackage is performed (which is very quick to do).